### PR TITLE
fix DrawElement

### DIFF
--- a/pslisp.ps
+++ b/pslisp.ps
@@ -76,8 +76,7 @@ symbol_set 0 0 put
         exit
       }if
       pop
-      (object) StringToSymbol tmp_x tmp_y DrawElement
-      exit
+      /tmp_c (object) StringToSymbol def  % retry
     }loop
   end
 }def

--- a/pslisp.ps
+++ b/pslisp.ps
@@ -76,8 +76,7 @@ symbol_set 0 0 put
         exit
       }if
       pop
-      (object) StringToSymbol tmp_x tmp_y DrawSymbol
-      CONS_W
+      (object) StringToSymbol tmp_x tmp_y DrawElement
       exit
     }loop
   end


### PR DESCRIPTION
`DrawElement` fails when printing SUBR or EXPR.
This PR fixes it.